### PR TITLE
[BUGFIX] Fix MySQL error in upgrade script

### DIFF
--- a/app/code/community/Adyen/Payment/sql/adyen_setup/mysql4-upgrade-2.1.2.1-2.1.2.2.php
+++ b/app/code/community/Adyen/Payment/sql/adyen_setup/mysql4-upgrade-2.1.2.1-2.1.2.2.php
@@ -28,6 +28,6 @@ $installer = $this;
 /* @var $installer Adyen_Payment_Model_Mysql4_Setup */
 
 $installer->startSetup();
-$installer->run("ALTER TABLE `{$this->getTable('adyen/event')}` ADD INDEX (`adyen_event_result`);");
+$installer->run("ALTER TABLE `{$this->getTable('adyen/event')}` ADD INDEX (`adyen_event_result`(255));");
 
 $installer->endSetup();


### PR DESCRIPTION
Fixes following error:

SQLSTATE[42000]: Syntax error or access violation: 1170 BLOB/TEXT
column 'adyen_event_result' used in key specification without a key length