### PR TITLE
getSkinUrl method accept path with slashes only

### DIFF
--- a/app/code/community/Adyen/Payment/Block/Form/Boleto.php
+++ b/app/code/community/Adyen/Payment/Block/Form/Boleto.php
@@ -28,7 +28,7 @@
 class Adyen_Payment_Block_Form_Boleto extends Mage_Payment_Block_Form {
 
     protected function _construct() {
-        $paymentMethodIcon = $this->getSkinUrl('images'.DS.'adyen'.DS."img_trans.gif");
+        $paymentMethodIcon = $this->getSkinUrl('images/adyen/img_trans.gif');
         $label = Mage::helper('adyen')->_getConfigData("title", "adyen_boleto");
 
         $mark = Mage::getConfig()->getBlockClassName('core/template');

--- a/app/code/community/Adyen/Payment/Block/Form/Cc.php
+++ b/app/code/community/Adyen/Payment/Block/Form/Cc.php
@@ -30,7 +30,7 @@ class Adyen_Payment_Block_Form_Cc extends Mage_Payment_Block_Form_Cc {
     protected function _construct() {
         parent::_construct();
 
-        $paymentMethodIcon = $this->getSkinUrl('images'.DS.'adyen'.DS."img_trans.gif");
+        $paymentMethodIcon = $this->getSkinUrl('images/adyen/img_trans.gif');
         $label = Mage::helper('adyen')->_getConfigData("title", "adyen_cc");
 
         $mark = Mage::getConfig()->getBlockClassName('core/template');
@@ -44,7 +44,7 @@ class Adyen_Payment_Block_Form_Cc extends Mage_Payment_Block_Form_Cc {
             ->setMethodTitle('')
             ->setMethodLabelAfterHtml($mark->toHtml());
     }
-	
+
     /**
      * Retrieve availables credit card types
      *
@@ -53,18 +53,18 @@ class Adyen_Payment_Block_Form_Cc extends Mage_Payment_Block_Form_Cc {
     public function getCcAvailableTypes() {
         return $this->getMethod()->getAvailableCCTypes();
     }
-    
+
     public function isCseEnabled() {
         return $this->getMethod()->isCseEnabled();
     }
     public function getCsePublicKey() {
         return $this->getMethod()->getCsePublicKey();
     }
-	
+
     public function getPossibleInstallments(){
         return $this->getMethod()->getPossibleInstallments();
     }
-    
+
     public function hasInstallments(){
         return Mage::helper('adyen/installments')->isInstallmentsEnabled();
     }

--- a/app/code/community/Adyen/Payment/Block/Form/Elv.php
+++ b/app/code/community/Adyen/Payment/Block/Form/Elv.php
@@ -28,7 +28,7 @@
 class Adyen_Payment_Block_Form_Elv extends Mage_Payment_Block_Form {
 
     protected function _construct() {
-        $paymentMethodIcon = $this->getSkinUrl('images'.DS.'adyen'.DS."img_trans.gif");
+        $paymentMethodIcon = $this->getSkinUrl('images/adyen/img_trans.gif');
         $label = Mage::helper('adyen')->_getConfigData("title", "adyen_elv");
 
         $mark = Mage::getConfig()->getBlockClassName('core/template');

--- a/app/code/community/Adyen/Payment/Block/Form/Openinvoice.php
+++ b/app/code/community/Adyen/Payment/Block/Form/Openinvoice.php
@@ -37,7 +37,7 @@ class Adyen_Payment_Block_Form_Openinvoice extends Mage_Payment_Block_Form {
     protected $_address;
 
     protected function _construct() {
-        $paymentMethodIcon = $this->getSkinUrl('images'.DS.'adyen'.DS."img_trans.gif");
+        $paymentMethodIcon = $this->getSkinUrl('images/adyen/img_trans.gif');
         $label = Mage::helper('adyen')->_getConfigData("title", "adyen_openinvoice");
         // check if klarna or afterpay is selected for showing correct logo
         $openinvoiceType = Mage::helper('adyen')->_getConfigData("openinvoicetypes", "adyen_openinvoice");

--- a/app/code/community/Adyen/Payment/Block/Form/Pos.php
+++ b/app/code/community/Adyen/Payment/Block/Form/Pos.php
@@ -28,7 +28,7 @@
 class Adyen_Payment_Block_Form_Pos extends Mage_Payment_Block_Form {
 
     protected function _construct() {
-        $paymentMethodIcon = $this->getSkinUrl('images'.DS.'adyen'.DS."img_trans.gif");
+        $paymentMethodIcon = $this->getSkinUrl('images/adyen/img_trans.gif');
         $label = Mage::helper('adyen')->_getConfigData("title", "adyen_pos");
 
         $mark = Mage::getConfig()->getBlockClassName('core/template');

--- a/app/code/community/Adyen/Payment/Block/Form/Sepa.php
+++ b/app/code/community/Adyen/Payment/Block/Form/Sepa.php
@@ -28,7 +28,7 @@
 class Adyen_Payment_Block_Form_Sepa extends Mage_Payment_Block_Form {
 
     protected function _construct() {
-        $paymentMethodIcon = $this->getSkinUrl('images'.DS.'adyen'.DS."img_trans.gif");
+        $paymentMethodIcon = $this->getSkinUrl('images/adyen/img_trans.gif');
         $label = Mage::helper('adyen')->_getConfigData("title", "adyen_sepa");
 
         $mark = Mage::getConfig()->getBlockClassName('core/template');

--- a/app/design/frontend/base/default/template/adyen/form/cc.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/cc.phtml
@@ -30,7 +30,7 @@
 <li class="adyen_payment_creditcard_labels">
     <?php $count = 0;
     foreach ($this->getCcAvailableTypes() as $_typeCode => $_typeName): ?>
-        <?php $_filename = $this->getSkinUrl('images'.DS.'adyen'.DS. strtolower($_typeCode) . "_small.png"); ?>
+        <?php $_filename = $this->getSkinUrl('images/adyen/' . strtolower($_typeCode) . "_small.png"); ?>
         <img id="cc_type_<?php echo $count; ?>" width="40" height="22" src="<?php echo $_filename; ?>" alt="" class="mid" />
         <?php ++$count;
     endforeach; ?>

--- a/app/design/frontend/base/default/template/adyen/form/hpp.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/hpp.phtml
@@ -43,14 +43,14 @@
                 <div class="input-box required-entry">
                     <?php foreach ($enabledTypes as $_typeCode=>$_type): ?>
                     <?php $_typeName = $_type['name']; ?>
-                    <?php $filename = $this->getSkinUrl('images'.DS.'adyen'.DS. $_typeCode . ".png"); ?>
+                    <?php $filename = $this->getSkinUrl('images/adyen/' . $_typeCode . ".png"); ?>
                             <table class="table_adyen_<?php echo $_typeCode; ?>">
                                 <tr class="adyen_payment_method_row">
                                     <td class="col_radio" width="20px">
                                         <input type="radio" id="hpp_type_<?php echo $_typeCode ?>" name="payment[hpp_type]" value="<?php echo $_typeCode ?>"/>
                                         <input type="hidden" name="payment[hpp_type_label_<?php echo $_typeCode ?>]" value="<?php echo $_typeName; ?>" />
                                     </td>
-                                    <td class="col_img" width="80px"><label for="hpp_type_<?php echo $_typeCode ?>"><img src="<?php echo $this->getSkinUrl('images'.DS.'adyen'.DS."$_typeCode.png") ?>" alt="<?php echo $_typeName ?>" /></label></td>
+                                    <td class="col_img" width="80px"><label for="hpp_type_<?php echo $_typeCode ?>"><img src="<?php echo $this->getSkinUrl('images/adyen/' . "$_typeCode.png") ?>" alt="<?php echo $_typeName ?>" /></label></td>
 
                                     <?php if ($_typeName == "pm.c_cash.buttonName"):
                                             $_typeName = "Cash";
@@ -66,7 +66,7 @@
                                                     foreach ($_type['issuers'] as $_issueId => $_IssueLabel): ?>
                                                         <?php
                                                         $_bankFile = strtoupper(str_replace(" ", '', $_IssueLabel));
-                                                        $_filename = $this->getSkinUrl('images'.DS.'adyen'.DS. $_bankFile . ".png");
+                                                        $_filename = $this->getSkinUrl('images/adyen/' . $_bankFile . ".png");
                                                         if (empty($_issueId) || empty($_IssueLabel)) continue;
                                                         ?>
                                                         <table class="banks">
@@ -74,7 +74,7 @@
                                                                 <td width="20px">
                                                                     <input type="radio" id="hpp_ideal_type_<?php echo $_issueId ?>" name="payment[hpp_ideal_type]" value="<?php echo $_issueId .DS. $_IssueLabel ?>"/>
                                                                 </td>
-                                                                <td width="80px"><label for="hpp_ideal_type_<?php echo $_issueId ?>"><img src="<?php echo $this->getSkinUrl('images'.DS.'adyen'.DS."$_bankFile.png") ?>" alt="<?php echo $_IssueLabel ?>" label="<?php echo $_IssueLabel ?>" /></label></td>
+                                                                <td width="80px"><label for="hpp_ideal_type_<?php echo $_issueId ?>"><img src="<?php echo $this->getSkinUrl('images/adyen/' . "$_bankFile.png") ?>" alt="<?php echo $_IssueLabel ?>" label="<?php echo $_IssueLabel ?>" /></label></td>
                                                             </tr>
                                                         </table>
                                                         <script type="text/javascript">

--- a/app/design/frontend/base/default/template/adyen/form/oneclick.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/oneclick.phtml
@@ -58,7 +58,7 @@
 
                         ?>
                         <?php if (file_exists($_filename)){ ?>
-                            <img src="<?php echo $this->getSkinUrl('images'.DS.'adyen'.DS. $_bankFile . "_small.png") ?>" alt="<?php echo $_bankFile ?>" label="<?php echo $_bankFile ?>" />
+                            <img src="<?php echo $this->getSkinUrl('images/adyen/' . $_bankFile . "_small.png") ?>" alt="<?php echo $_bankFile ?>" label="<?php echo $_bankFile ?>" />
                         <?php } ?>
 
 

--- a/app/design/frontend/base/default/template/adyen/saved_cards.phtml
+++ b/app/design/frontend/base/default/template/adyen/saved_cards.phtml
@@ -59,7 +59,7 @@
 
                             ?>
                             <?php if (file_exists($_filename)){ ?>
-                                <img src="<?php echo $this->getSkinUrl('images'.DS.'adyen'.DS. $_bankFile . "_small.png") ?>" alt="<?php echo $_bankFile ?>" label="<?php echo $_bankFile ?>" />
+                                <img src="<?php echo $this->getSkinUrl('images/adyen/' . $_bankFile . "_small.png") ?>" alt="<?php echo $_bankFile ?>" label="<?php echo $_bankFile ?>" />
                             <?php } ?>
 
 


### PR DESCRIPTION
Magento returns invalid url if backslashes are found within file path:

The generated url is not correct and don't works:
```
example.com/skin/frontend/base/default/images\adyen\ae_small.png
```

This fix removes this issue.

P.S. I found that [you are using](https://github.com/adyenpayments/magento/blob/develop-2.3.0/app/design/frontend/base/default/template/adyen/form/hpp.phtml#L94) `DS` as value separator in inputs. I don't think you did that purposely, or am I wrong?